### PR TITLE
JDP230701-16_BUG-01-fix

### DIFF
--- a/src/main/java/com/kodilla/ecommercee/domain/Order.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/Order.java
@@ -29,7 +29,7 @@ public class Order {
     private LocalDate created;
 
     @ManyToOne(
-            cascade = CascadeType.ALL,
+            cascade = {CascadeType.DETACH,CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH},
             fetch = FetchType.LAZY
     )
     @JoinColumn(name = "USER_ID")


### PR DESCRIPTION
Zmieniona kaskada w encji Orders w celu wyeliminowania błędu kasowania powiązanego z zamówieniem Użytkownika  po usunięcia rekordu z Orders 